### PR TITLE
Update TrinucleotideMatrix.R

### DIFF
--- a/R/TrinucleotideMatrix.R
+++ b/R/TrinucleotideMatrix.R
@@ -137,6 +137,20 @@ trinucleotideMatrix = function(maf, ref_genome, prefix = NULL, add = TRUE, ignor
   names(conv) = c('A>G', 'T>C', 'C>T', 'G>A', 'A>T', 'T>A', 'A>C', 'T>G', 'C>A', 'G>T', 'C>G', 'G>C')
 
   extract.tbl$SubstitutionType = conv[extract.tbl$Substitution]
+  
+  #need to reverse-complement triplet for mutated purines (not just the middle base)
+  complemented.triplets = paste(
+  complement[
+    substr(x = as.character(extract.tbl$trinucleotide), 3, 3)],
+  '[',extract.tbl$SubstitutionType, ']', 
+  complement[substr(as.character(extract.tbl$trinucleotide), 1, 1)],
+  sep='')
+  #which ones need to be reverse-complemented
+  swap.ind = which(substr(x=extract.tbl$Substitution,1,1) %in% c("G","A"))
+  swapSubTypeMotif =  extract.tbl$SubstitutionTypeMotif = paste(substr(x = as.character(extract.tbl$trinucleotide), 1, 1),'[',extract.tbl$SubstitutionType, ']', substr(as.character(extract.tbl$trinucleotide), 3, 3), sep='')
+  swapSubTypeMotif[swap.ind] = complemented.triplets[swap.ind]
+
+  extract.tbl$SubstitutionTypeMotif = swapSubTypeMotif
   extract.tbl$SubstitutionTypeMotif = paste(substr(x = as.character(extract.tbl$trinucleotide), 1, 1),'[',extract.tbl$SubstitutionType, ']', substr(as.character(extract.tbl$trinucleotide), 3, 3), sep='')
 
   #Possible substitutions and and their motifs

--- a/R/TrinucleotideMatrix.R
+++ b/R/TrinucleotideMatrix.R
@@ -137,7 +137,8 @@ trinucleotideMatrix = function(maf, ref_genome, prefix = NULL, add = TRUE, ignor
   names(conv) = c('A>G', 'T>C', 'C>T', 'G>A', 'A>T', 'T>A', 'A>C', 'T>G', 'C>A', 'G>T', 'C>G', 'G>C')
 
   extract.tbl$SubstitutionType = conv[extract.tbl$Substitution]
-  
+  complement=c("A","C","G","T")
+  names(complement)=c("T","G","C","A")
   #need to reverse-complement triplet for mutated purines (not just the middle base)
   complemented.triplets = paste(
   complement[

--- a/R/TrinucleotideMatrix.R
+++ b/R/TrinucleotideMatrix.R
@@ -151,7 +151,7 @@ trinucleotideMatrix = function(maf, ref_genome, prefix = NULL, add = TRUE, ignor
   swapSubTypeMotif[swap.ind] = complemented.triplets[swap.ind]
 
   extract.tbl$SubstitutionTypeMotif = swapSubTypeMotif
-  extract.tbl$SubstitutionTypeMotif = paste(substr(x = as.character(extract.tbl$trinucleotide), 1, 1),'[',extract.tbl$SubstitutionType, ']', substr(as.character(extract.tbl$trinucleotide), 3, 3), sep='')
+  #extract.tbl$SubstitutionTypeMotif = paste(substr(x = as.character(extract.tbl$trinucleotide), 1, 1),'[',extract.tbl$SubstitutionType, ']', substr(as.character(extract.tbl$trinucleotide), 3, 3), sep='')
 
   #Possible substitutions and and their motifs
   sub.levels = extract.tbl[,.N,Substitution][,Substitution]


### PR DESCRIPTION
Unless I misunderstood something or this is dealt with later in the code, believe there was a major bug in this function. The immediate 5' and 3' base of the mutated nucleotide must be the reverse-complemented for any purine. In the prior code, A[G>T]C was being converted to A[C>A]G etc. The correct conversion would be G[C>A]T, for this example. 
Rationale:
duplex for triplet
5'-AGC-3'
3'-TCG-5'

C is flanked by G(upstream, 5') and T (downstream, 3' side), hence GCT or G[C>A]T. Please feel free to reject this pull request if I'm mistaken and this is already handled properly elsewhere in the code.