### PR TITLE
fix plot error caused by NAs in signatureEnrichment

### DIFF
--- a/R/signatureCorrelation.R
+++ b/R/signatureCorrelation.R
@@ -89,7 +89,7 @@ signatureEnrichment = function(maf, sig_res, minMut = 5, useCNV = FALSE, fn = NU
   #layout(matrix(1:1, ncol=2, byrow = TRUE), heights=c(1,1,1,0.2))
   title_size = 1
   par(mar = c(3.5,2.5,2,2))
-  b = barplot(as.matrix(sig.mean.stat), ylim = c(0, 1 + max(sig.sd.stat)), col = cols,
+  b = barplot(as.matrix(sig.mean.stat), ylim = c(0, 1 + max(sig.sd.stat, na.rm = TRUE)), col = cols,
               axes = FALSE, border = 0.1, xaxt = "n")
   for(i in 1:ncol(sig.sd.stat)){
     segments(x0 = b[i], y0 = cumsum(sig.mean.stat[,i]) - sig.sd.stat[,i],

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@
 [![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/poisonalien/maftools.svg)](https://github.com/poisonalien/maftools/issues)
 [![Github Stars](https://img.shields.io/github/stars/poisonalien/maftools.svg?style=social&label=Github)](https://github.com/poisonalien/maftools)
 
-## Note
-
-This packaege forked from **PoisonAlien/maftools** is used to do some modification for fitting my usage.
-
 
 ## Introduction. 
 With advances in Cancer Genomics, Mutation Annotation Format (MAF) is being widley accepted and used to store variants detected. 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 [![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/poisonalien/maftools.svg)](https://github.com/poisonalien/maftools/issues)
 [![Github Stars](https://img.shields.io/github/stars/poisonalien/maftools.svg?style=social&label=Github)](https://github.com/poisonalien/maftools)
 
+## Note
+
+This packaege forked from **PoisonAlien/maftools** is used to do some modification for fitting my usage.
+
 
 ## Introduction. 
 With advances in Cancer Genomics, Mutation Annotation Format (MAF) is being widley accepted and used to store variants detected. 


### PR DESCRIPTION
Hello @PoisonAlien,

this commit is to fix the problem when I used `signatureEnrichment`, a signature include only one  sample and made NAs in `sig.sd.stat` in the function. This caused the whole function halt and return an error.

![image](https://user-images.githubusercontent.com/25057508/41342741-9019350c-6f2f-11e8-89d0-f97e2d4a850e.png)


![image](https://user-images.githubusercontent.com/25057508/41342709-7aea6674-6f2f-11e8-9372-8c2e88082736.png)

just add `na.rm=TRUE` and works fine now.

![image](https://user-images.githubusercontent.com/25057508/41343005-1cddfa90-6f30-11e8-8e82-e9bb0b4febef.png)


