### PR TITLE
remove top_annotation_height argument for Heatmaps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ LazyData: TRUE
 Depends: R (>= 3.3)
 Imports: data.table, ggplot2(>= 2.0), cowplot, cometExactTest,
         RColorBrewer, NMF, ggrepel, methods,
-        ComplexHeatmap, mclust, Biostrings,
+        ComplexHeatmap (>= 1.99.0), mclust, Biostrings,
         rjson, grid, wordcloud, grDevices, gridExtra, survival, BSgenome
 RoxygenNote: 6.1.0
 Encoding: UTF-8

--- a/R/getOncoPlot.R
+++ b/R/getOncoPlot.R
@@ -315,14 +315,14 @@ getOncoPlot = function(maf, genes, removeNonMutated = FALSE, colors = NULL, show
     if(!is.null(clinicalFeatures)){
       ht = ComplexHeatmap::Heatmap(matrix = mat, rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                    show_column_names = showTumorSampleBarcodes, show_heatmap_legend = FALSE,
-                                   top_annotation_height = grid::unit(2, "cm"), show_row_names = FALSE,
+                                   show_row_names = FALSE,
                                    column_title =  hmName, column_names_gp = grid::gpar(fontsize = fs), bottom_annotation = bot.anno,
                                    column_title_gp = grid::gpar(fontsize = tfs, fontface = "bold"))
 
     }else{
       ht = ComplexHeatmap::Heatmap(matrix = mat, rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                    show_column_names = showTumorSampleBarcodes, show_heatmap_legend = FALSE,
-                                   top_annotation_height = grid::unit(2, "cm"), show_row_names = FALSE,
+                                   show_row_names = FALSE,
                                    column_title =  hmName, column_names_gp = grid::gpar(fontsize = fs),
                                    column_title_gp = grid::gpar(fontsize = tfs, fontface = "bold"))
     }

--- a/R/oncoplot.R
+++ b/R/oncoplot.R
@@ -436,9 +436,9 @@ oncoplot = function (maf, top = 20, genes = NULL, mutsig = NULL, mutsigQval = 0.
   }
 
   if(colbar_pathway){
-    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar2, which = "column", height = grid.unit(2, "cm"))
+    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar2, which = "column", height = grid::unit(2, "cm"))
   }else{
-    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar, which = "column", height = grid.unit(2, "cm"))
+    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar, which = "column", height = grid::unit(2, "cm"))
   }
 
 

--- a/R/oncoplot.R
+++ b/R/oncoplot.R
@@ -436,9 +436,9 @@ oncoplot = function (maf, top = 20, genes = NULL, mutsig = NULL, mutsigQval = 0.
   }
 
   if(colbar_pathway){
-    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar2, which = "column")
+    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar2, which = "column", height = grid.unit(2, "cm"))
   }else{
-    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar, which = "column")
+    ha_column_bar = ComplexHeatmap::HeatmapAnnotation(column_bar = anno_column_bar, which = "column", height = grid.unit(2, "cm"))
   }
 
 
@@ -511,14 +511,13 @@ oncoplot = function (maf, top = 20, genes = NULL, mutsig = NULL, mutsigQval = 0.
       ht = ComplexHeatmap::Heatmap(mat, na_col = bg,rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                    row_names_gp = grid::gpar(fontsize = fontSize, fontface = "bold"), show_column_names = showTumorSampleBarcodes,
                                    show_heatmap_legend = FALSE, top_annotation = ha_column_bar,
-                                   top_annotation_height = grid::unit(2, "cm"),
                                    column_title_gp = grid::gpar(fontsize = titleFontSize, fontface = "bold"), column_title = altStat)
     } else{
 
       ht = ComplexHeatmap::Heatmap(mat, na_col = bg,rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                    row_names_gp = grid::gpar(fontsize = fontSize, fontface = "bold"), show_column_names = showTumorSampleBarcodes,
                                    show_heatmap_legend = FALSE, top_annotation = ha_column_bar,
-                                   top_annotation_height = grid::unit(2, "cm"), bottom_annotation = bot.anno,
+                                   bottom_annotation = bot.anno,
                                    column_title_gp = grid::gpar(fontsize = titleFontSize, fontface = "bold"), column_title = altStat)
     }
 

--- a/R/oncostrip.R
+++ b/R/oncostrip.R
@@ -285,12 +285,12 @@ oncostrip = function(maf, genes = NULL, top = 5, colors = NULL, sort = TRUE, cli
   if(is.null(clinicalFeatures)){
     ht = ComplexHeatmap::Heatmap(mat, rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                  row_names_gp = grid::gpar(fontsize = fontSize, fontface = "bold"), show_column_names = showTumorSampleBarcodes,
-                                 show_heatmap_legend = FALSE, top_annotation_height = grid::unit(2, "cm"), column_title = altStat,
+                                 show_heatmap_legend = FALSE, column_title = altStat,
                                  column_title_gp = gpar(fontsize = titleFontSize, fontface = "bold"))
   }else{
     ht = ComplexHeatmap::Heatmap(mat, rect_gp = grid::gpar(type = "none"), cell_fun = celFun,
                                  row_names_gp = grid::gpar(fontsize = fontSize, fontface = "bold"), show_column_names = showTumorSampleBarcodes,
-                                 show_heatmap_legend = FALSE, top_annotation_height = grid::unit(2, "cm"),
+                                 show_heatmap_legend = FALSE,
                                  bottom_annotation = bot.anno, column_title = altStat,
                                  column_title_gp = gpar(fontsize = titleFontSize, fontface = "bold"))
   }


### PR DESCRIPTION
Hello, first thanks for using ComplexHeatmap!

I recently updated the ComplexHeatmap package and I slightly changed arguments for some functions. One of the removed argument is `top_annotation_height` in `Heatmap()` function, and now the height of the annotations is only controlled in `HeatmapAnnotation()` function. I noticed some of your functions still use `top_annotation_height` argument and it will break the checking or building of your package in the future.

I made small changes to your package, basically to make it consistent with the new version of ComplexHeatmap. You can merge it if you find it useful.

Cheers,
Zuguang
