### PR TITLE
fixed handling of Status in survival

### DIFF
--- a/R/mafSuvival.R
+++ b/R/mafSuvival.R
@@ -104,7 +104,7 @@ mafSurvival = function(maf, genes = NULL, samples = NULL, clinicalData = NULL, t
   data.table::setDT(clinicalData)
 
   clinicalData$Time = suppressWarnings( as.numeric(as.character(clinicalData$Time)) )
-  clinicalData$Status = suppressWarnings( as.integer(as.character(clinicalData$Status)) )
+  clinicalData$Status = suppressWarnings( as.integer(clinicalData$Status) )
   clinicalData$Group = ifelse(test = clinicalData$Tumor_Sample_Barcode %in% genesTSB, yes = groupNames[1], no = groupNames[2])
   clin.mut.dat = clinicalData[,.(medianTime = median(Time, na.rm = TRUE),N = .N), Group][order(Group)]
   message("Median survival..")


### PR DESCRIPTION
I believe Status is handled strangely in `mafSurvival()`. 
Line 107 converts `Status` like this:
```
 clinicalData$Status = suppressWarnings( as.integer(as.character(clinicalData$Status) ))
```
If Status is logical, this line converts all elements to `NA`'s. 
At line 118, all rows will be filtered out and the script fails at line 120.