### PR TITLE
Fix a bug of annovarToMaf, in case of ANNOVAR results without non-exonic variants

### DIFF
--- a/R/annovarToMaf.R
+++ b/R/annovarToMaf.R
@@ -163,6 +163,11 @@ annovarToMaf = function(annovar, Center = NULL, refBuild = 'hg19', tsbCol = NULL
       ann = data.table::rbindlist(l = list(ann_exonic, ann_res), use.names = TRUE, fill = TRUE)
     }
 
+    # In case of ANNOVAR results without non-exonic variants
+    if(nrow(ann_res) == 0){
+      ann = ann_exonic
+    }
+
     #Add Variant-type annotations based on difference between ref and alt alleles
     cat("-Adding Variant_Type\n")
     ann[,ref_alt_diff := nchar(Ref) - nchar(Alt)]


### PR DESCRIPTION
If a VCF file contains only exonic variants, then annovarToMaf will throw out an error like:
```
-Adding Variant_Type
Error in .checkTypos(e, names(x)): Object 'Variant_Classification' not found amongst Tumor_Sample_Barcode, Chr, Start, End, Ref and 9 more
Traceback:
```

This error occurs because of if(nrow(ann_res) == 0), the command
```
ann = data.table::rbindlist(l = list(ann_exonic, ann_res), use.names = TRUE, fill = TRUE)
```
will not be performed.

