### PR TITLE
Fix data merge issue, releated to #628

### DIFF
--- a/R/rainfallPlot.R
+++ b/R/rainfallPlot.R
@@ -99,12 +99,14 @@ rainfallPlot = function(maf, tsb = NULL, detectChangePoints = FALSE,
     if(nrow(maf.cpt) == 0){
       message('No changepoints detected!')
     }else{
-      maf.snp[,id := paste0(Chromosome, ':', Start_Position)]
       maf.snp = maf.snp[!diff %in% 0]
       maf.snp[,minDiff := min(diff), by = .(Chromosome)]
-      maf.cpt[,id := paste0(Chromosome, ':', Start_Position)]
-      maf.cpt = merge(maf.snp[,.(id, Start_Position_updated, End_Position_updated, minDiff)], maf.cpt[,.(id)])
+      maf.snp[, Chromosome := as.character(Chromosome)]
+      maf.cpt[, Chromosome := as.character(Chromosome)]
+      data.table::setkey(maf.cpt, "Chromosome", "Start_Position", "End_Position")
+      maf.cpt = maf.snp[data.table::foverlaps(maf.snp, maf.cpt, which = TRUE, nomatch = NULL)$xid]
       maf.cpt[,pos := (End_Position_updated - Start_Position_updated)/2]
+      
       arrows(x0 = maf.cpt$Start_Position_updated, y0 = 0, x1 = maf.cpt$Start_Position_updated,
              y1 = maf.cpt$minDiff - 0.2, lwd = 1.2, length = 0.05)
     }


### PR DESCRIPTION
Hello @PoisonAlien,

I create this PR to close #628. It indicates that there is a bug in current code for merging SNP location and Kataegis regions.

The following code test if the new code works for the issue and also reports consistent results as show case in current vignette.

Please go further take a review carefully.

```r
# library(maftools)
devtools::load_all("~/Documents/GitHub/maftools/")
# the data is from #628 
maf = data.table::fread("example.MAF")
mafobj <- read.maf(maf, vc_nonSyn = unique(maf$Variant_Classification))

#debug(rainfallPlot)
rainfallPlot(maf = mafobj, detectChangePoints = TRUE, ref.build = "hg38", savePlot = TRUE)

brca <- system.file("extdata", "brca.maf.gz", package = "maftools")
brca = read.maf(maf = brca, verbose = FALSE)
rainfallPlot(maf = brca, detectChangePoints = TRUE, pointSize = 0.4)
```

Best,
Shixiang