### PR TITLE
Fix bug when plotting cobarplot for one gene, close #716

### DIFF
--- a/R/coBarplot.R
+++ b/R/coBarplot.R
@@ -162,9 +162,17 @@ get_col_df = function(m, g){
     return(data.frame(row.names = g, stringsAsFactors = FALSE))
   }
   ml = apply(createOncoMatrix(m = m, g = g, chatty = FALSE, add_missing = TRUE)[['oncoMatrix']], 1, table)
-  ml = lapply(ml, function(x){
-    data.frame(x)
-  })
+  if (!is.list(ml)) {
+    gene_name <- colnames(ml)[1]
+    ml <- list(
+      data.frame(Var1 = rownames(ml), Freq = ml[, gene_name])
+    )
+    names(ml) <- gene_name
+  } else {
+    ml = lapply(ml, function(x){
+      data.frame(x)
+    })
+  }
   ml = data.table::rbindlist(l = ml, use.names = TRUE, fill = TRUE, idcol = "Gene")
   ml = ml[!Var1 %in% ""]
   #CNV+Mutated = Complex_Event


### PR DESCRIPTION
Hi @PoisonAlien,

This PR is to fix bug from #716.

```
library(maftools)

primary.apl <- system.file("extdata", "APL_primary.maf.gz", package = "maftools")
relapse.apl <- system.file("extdata", "APL_relapse.maf.gz", package = "maftools")
primary.apl <- read.maf(maf = primary.apl)
relapse.apl <- read.maf(maf = relapse.apl)

coBarplot(m1 = primary.apl, m2 = relapse.apl,
          #genes = c("FLT3","WT1"),
          genes = c("WT1"),
          m1Name = 'Primary APL', m2Name = 'Relapse APL')
```

![image](https://user-images.githubusercontent.com/25057508/119105796-486a2d00-ba50-11eb-9d3b-6ede87239ed0.png)
