### PR TITLE
Renew forestPlot function

### DIFF
--- a/R/forestPlot.R
+++ b/R/forestPlot.R
@@ -26,7 +26,7 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
                       color=c('maroon','royalblue'),
                       geneFontSize = 0.8, titleSize = 1.2, lineWidth = 1){
 
-if(is.null(fdr)){
+  if(is.null(fdr)){
     m.sigs = mafCompareRes$results[pval < pVal]
   }else{
     m.sigs = mafCompareRes$results[adjPval < fdr]
@@ -38,10 +38,7 @@ if(is.null(fdr)){
   m1.sampleSize = mafCompareRes$SampleSummary[1, SampleSize]
   m2.sampleSize = mafCompareRes$SampleSummary[2, SampleSize]
 
-  
- 
-
-  # deal with colors info -> vc_col for usage   
+  # newly added, deal with parameter color -> vc_col for usage   
   vc_col = color
   if (length(color)==1){
     vc_col = c(color,color)
@@ -54,14 +51,14 @@ if(is.null(fdr)){
   if (is.null(names(vc_col))){
       names(vc_col)=c(m1Name,m2Name)
   }
-  
-  
+  # end of newly added
+    
   if(nrow(m.sigs) < 1){
     stop('No differetially mutated genes found !')
   }
 
   m.sigs$Hugo_Symbol = factor(x = m.sigs$Hugo_Symbol, levels = rev(m.sigs$Hugo_Symbol))
-
+  
   m.sigs$or_new = ifelse(test = m.sigs$or > 3, yes = 3, no = m.sigs$or)
   m.sigs$upper = ifelse(test = m.sigs$ci.up > 3, yes = 3, no = m.sigs$ci.up)
   m.sigs$lower = ifelse(test = m.sigs$ci.low > 3, yes = 3, no = m.sigs$ci.low)
@@ -72,13 +69,11 @@ if(is.null(fdr)){
   xlims = c(0, 4)
   ylims = c(0.75, nrow(m.sigs))
 
- 
-
- graphics::layout(mat = matrix(c(1, 2, 3, 4, 5, 6, 6, 6, 6, 6), byrow = TRUE, ncol = 5, nrow = 2), widths = c(4, 1, 1), heights = c(6, 1.2))
+  graphics::layout(mat = matrix(c(1, 2, 3, 4, 5, 6, 6, 6, 6, 6), byrow = TRUE, ncol = 5, nrow = 2), widths = c(4, 1, 1), heights = c(6, 1.2))
   par(mar = c(3, 1, 3, 5))
   plot(NA, xlim = xlims, ylim = ylims, axes= FALSE, xlab = NA, ylab = NA)
 
- apply(m.sigs[,.(or, ci.up, ci.low, ci.up, or_new, upper, lower, pos)], 1, function(x){
+  apply(m.sigs[,.(or, ci.up, ci.low, ci.up, or_new, upper, lower, pos)], 1, function(x){
     p = x[5]; u = x[6]; u_orig = x[2]; l = x[7]; l_orig = x[3]; ypos = x[8]
     if (p<1){
         linecolor = vc_col[m2Name]
@@ -100,8 +95,7 @@ if(is.null(fdr)){
     }
 
   })
- 
-
+  
   abline(v = 1, lty = 2, col = "gray", xpd = FALSE)
   axis(side = 1, at = 0:3, labels = c(0:3), font = 1, pos = 0.5, cex.axis = 1.3)
 
@@ -111,22 +105,23 @@ if(is.null(fdr)){
   title(main = mtitle, font = 1, adj = 0, cex.main = titleSize)
   #mtext(text = "Odds ratio", side = 1, line = 3, font = 1, cex = 0.7*(titleSize), adj = 0.25)
 
-  # plot annotation coloumns of the graph c(group1,group2,OR,p-value) col (col 2 ~ col 5)
+  # plot annotation columns of the graph c(group1,group2,OR,p-value) col (col 2 ~ col 5)
+  # annotation columns group2
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)
   text(x = 0.5, y = 1:nrow(m.sigs), labels = as.numeric(unlist(m.sigs[,3])),
        adj = 0, font = 1, cex = 1.4*(geneFontSize))
   title(main = m2Name, cex.main = titleSize)
-
+  # annotation columns group1
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)
   text(x = 0.5, y = 1:nrow(m.sigs), labels = as.numeric(unlist(m.sigs[,2])),
        adj = 0, font = 1, cex = 1.4*(geneFontSize))
   title(main = m1Name, cex.main = titleSize)
-
- par(mar = c(3, 0, 3, 0))
+  # annotation columns OR
+  par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)
   text(x = 0.5, y = 1:nrow(m.sigs), labels = round(m.sigs$or, digits = 3),
@@ -136,6 +131,7 @@ if(is.null(fdr)){
   m.sigs$significance = ifelse(test =  as.numeric(m.sigs$pval) < 0.001, yes = "***", no =
                                  ifelse(test = as.numeric(m.sigs$pval) < 0.01, yes = "**", no =
                                           ifelse(test = as.numeric(m.sigs$pval) < 0.05, yes = "*", no = "NS")))
+  # annotation columns P-value
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)

--- a/R/forestPlot.R
+++ b/R/forestPlot.R
@@ -23,9 +23,10 @@
 #' forestPlot(mafCompareRes = pt.vs.rt)
 
 forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
+                      color=c('maroon','royalblue'),
                       geneFontSize = 0.8, titleSize = 1.2, lineWidth = 1){
 
-  if(is.null(fdr)){
+if(is.null(fdr)){
     m.sigs = mafCompareRes$results[pval < pVal]
   }else{
     m.sigs = mafCompareRes$results[adjPval < fdr]
@@ -37,6 +38,24 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   m1.sampleSize = mafCompareRes$SampleSummary[1, SampleSize]
   m2.sampleSize = mafCompareRes$SampleSummary[2, SampleSize]
 
+  
+ 
+
+  # deal with colors info -> vc_col for usage   
+  vc_col = color
+  if (length(color)==1){
+    vc_col = c(color,color)
+  }else if(length(color==2)){
+    vc_col = color
+  }else{
+    stop('colors length must be less equal than 2')
+  }
+      
+  if (is.null(names(vc_col))){
+      names(vc_col)=c(m1Name,m2Name)
+  }
+  
+  
   if(nrow(m.sigs) < 1){
     stop('No differetially mutated genes found !')
   }
@@ -53,24 +72,35 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   xlims = c(0, 4)
   ylims = c(0.75, nrow(m.sigs))
 
-  graphics::layout(mat = matrix(c(1, 2, 3, 4, 5, 6, 6, 6, 6, 6), byrow = TRUE, ncol = 5, nrow = 2), widths = c(4, 1, 1), heights = c(6, 1.2))
+ 
+
+ graphics::layout(mat = matrix(c(1, 2, 3, 4, 5, 6, 6, 6, 6, 6), byrow = TRUE, ncol = 5, nrow = 2), widths = c(4, 1, 1), heights = c(6, 1.2))
   par(mar = c(3, 1, 3, 5))
   plot(NA, xlim = xlims, ylim = ylims, axes= FALSE, xlab = NA, ylab = NA)
-  apply(m.sigs[,.(or, ci.up, ci.low, ci.up, or_new, upper, lower, pos)], 1, function(x){
+
+ apply(m.sigs[,.(or, ci.up, ci.low, ci.up, or_new, upper, lower, pos)], 1, function(x){
     p = x[5]; u = x[6]; u_orig = x[2]; l = x[7]; l_orig = x[3]; ypos = x[8]
+    if (p<1){
+        linecolor = vc_col[m2Name]
+    }else if(p>1){
+        linecolor = vc_col[m1Name]
+    }else{
+        linecolor = 'black'
+    }
     points(x = p, y = ypos, pch = 16, cex = 1.1*(lineWidth))
-    segments(x0 = l, y0 = ypos, x1 = u, y1 = ypos, lwd = lineWidth)
+    segments(x0 = l, y0 = ypos, x1 = u, y1 = ypos, lwd = lineWidth,col = linecolor)
 
     if(u_orig >3){
-      segments(x0 = 3, y0 = ypos, x1 = 3.25, y1 = ypos, lwd = lineWidth)
+      segments(x0 = 3, y0 = ypos, x1 = 3.25, y1 = ypos, lwd = lineWidth,col=linecolor)
       points(x = 3.25, y = ypos, pch = ">", cex = 1.1*(lineWidth))
     }
     if(l_orig >3){
-      segments(x0 = 3, y0 = ypos, x1 = 3.25, y1 = ypos, lwd = lineWidth)
+      segments(x0 = 3, y0 = ypos, x1 = 3.25, y1 = ypos, lwd = lineWidth,col=linecolor)
       points(x = 3.25, y = ypos, pch = ">", cex = 1.1*(lineWidth))
     }
 
   })
+ 
 
   abline(v = 1, lty = 2, col = "gray", xpd = FALSE)
   axis(side = 1, at = 0:3, labels = c(0:3), font = 1, pos = 0.5, cex.axis = 1.3)
@@ -81,13 +111,7 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   title(main = mtitle, font = 1, adj = 0, cex.main = titleSize)
   #mtext(text = "Odds ratio", side = 1, line = 3, font = 1, cex = 0.7*(titleSize), adj = 0.25)
 
-  par(mar = c(3, 0, 3, 0))
-  plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
-       pch = NA, xlab = "", ylab = "", ylim = ylims)
-  text(x = 0.5, y = 1:nrow(m.sigs), labels = as.numeric(unlist(m.sigs[,2])),
-       adj = 0, font = 1, cex = 1.4*(geneFontSize))
-  title(main = m1Name, cex.main = titleSize)
-
+  # plot annotation coloumns of the graph c(group1,group2,OR,p-value) col (col 2 ~ col 5)
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)
@@ -98,15 +122,20 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)
+  text(x = 0.5, y = 1:nrow(m.sigs), labels = as.numeric(unlist(m.sigs[,2])),
+       adj = 0, font = 1, cex = 1.4*(geneFontSize))
+  title(main = m1Name, cex.main = titleSize)
+
+ par(mar = c(3, 0, 3, 0))
+  plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
+       pch = NA, xlab = "", ylab = "", ylim = ylims)
   text(x = 0.5, y = 1:nrow(m.sigs), labels = round(m.sigs$or, digits = 3),
        adj = 0.5, font = 1, cex = 1.4*(geneFontSize))
   title(main = "OR", cex.main = titleSize)
-
-
+  
   m.sigs$significance = ifelse(test =  as.numeric(m.sigs$pval) < 0.001, yes = "***", no =
                                  ifelse(test = as.numeric(m.sigs$pval) < 0.01, yes = "**", no =
                                           ifelse(test = as.numeric(m.sigs$pval) < 0.05, yes = "*", no = "NS")))
-
   par(mar = c(3, 0, 3, 0))
   plot(rep(0, nrow(m.sigs)), 1:nrow(m.sigs), xlim = c(0, 1), axes = FALSE,
        pch = NA, xlab = "", ylab = "", ylim = ylims)

--- a/R/forestPlot.R
+++ b/R/forestPlot.R
@@ -39,7 +39,6 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   m2.sampleSize = mafCompareRes$SampleSummary[2, SampleSize]
 
   # newly added, deal with parameter color -> vc_col for usage   
-  vc_col = color
   if (length(color)==1){
     vc_col = c(color,color)
   }else if(length(color==2)){

--- a/R/forestPlot.R
+++ b/R/forestPlot.R
@@ -48,7 +48,15 @@ forestPlot = function(mafCompareRes, pVal = 0.05, fdr = NULL,
   }
       
   if (is.null(names(vc_col))){
-      names(vc_col)=c(m1Name,m2Name)
+      names(vc_col)=c(m2Name,m1Name)
+  }else if (!(m1Name %in% names(vc_col)) && !(m2Name %in% names(vc_col))){
+          stop(paste0('\ninput named vector [color] must contain both group name, \nwhich should be like c(',
+                m1Name,', ', m2Name,') but now are ',list(names(vc_col)),'\n'))
+  }else if ( !(m1Name %in% names(vc_col)) || !(m2Name %in% names(vc_col)) ){
+    
+      stop(paste0('\nif you pass [color] with named vector, then both of the names matching group names must be Explicitly declared,\n',
+                  'which should be like c(',
+                m1Name,', ', m2Name,') but now are ',list(names(vc_col)),'\n'))
   }
   # end of newly added
     


### PR DESCRIPTION
1. The lastest version maftools(v0.9.30, version 2.8.0 in bioconductor) do not support ```color=c()``` paramter in ```forestPlot``` function which is not compatible with older versions(like version 2.4.0 in bioconductor)
re-Add color parameter which controls the color of the line depending on the location of the line (current OR threhold value is 1, will be 0 if using log(OR))
```color=c('maroon','royalblue')```: vector of colors or named vector of colors for each ```Variant_Classification``` (group)
makes it compatible with older version of maftools.

1. change the annotation columns order of the plot, makes it be accord with the group name order aprears on the left graphic.
eg. In the offical demo data, former graph produced was Group Relapse/Primary in the left graph and Primary, Relapse, OR, P-value in the right annotation.
![image](https://user-images.githubusercontent.com/15091103/129870837-fdeeb3d9-cedc-4da7-8990-5772c12e6570.png)
After the change, the apprearance is  Relapse/Primary in the left graph and Relapse, Primary, OR, P-value in the right annotation with lines in the left graph full of color 😃
![image](https://user-images.githubusercontent.com/15091103/129871208-0eb01452-c1f3-49bf-8bdb-4776c1e26750.png)
(I have changed the ```geneFontSize=1.4```,```titleSize=2```,```lineWidth=2``` under my display settings to make the graph look good.)

1. After the change, I think the graph is more intuitive to interpret, for if you see the line trend to left in the left graph, the in the right annotation, the left group shows more cases than the right one.
e.g. for the PML gene, in the left graph field, the red line trends to go left, and in the right annotation field, the left Relapse group has more patient than the right Primary group.