### PR TITLE
Fix the clinicalEnrichment() using pathways

### DIFF
--- a/R/ClinicalEnrichment.R
+++ b/R/ClinicalEnrichment.R
@@ -88,7 +88,7 @@ clinicalEnrichment = function(maf, clinicalFeature = NULL, annotationDat = NULL,
   plist = lapply(genes, function(x){
           if(pathways){
             pathgenes = pathdb[[x]][,Gene]
-            g = unique(unlist(genesToBarcodes(maf = maf, genes = x, justNames = TRUE, verbose = FALSE)))
+            g = unique(unlist(genesToBarcodes(maf = maf, genes = pathgenes, justNames = TRUE, verbose = FALSE)))
           }else{
             g = unique(genesToBarcodes(maf = maf, genes = x, justNames = TRUE)[[1]])
           }


### PR DESCRIPTION
The previous version of clinicalEnrichment can only perform the enrichment of TP53 and MYC because the pathway names are gene symbols. Now the pathway enrichment can work as expected.