### PR TITLE
in case if NCBI_Build column exist with missing values 

### DIFF
--- a/R/summarizeMaf.R
+++ b/R/summarizeMaf.R
@@ -8,6 +8,7 @@ summarizeMaf = function(maf, anno = NULL, chatty = TRUE){
   if('NCBI_Build' %in% colnames(maf)){
     NCBI_Build = unique(maf[!Variant_Type %in% 'CNV', NCBI_Build])
     NCBI_Build = NCBI_Build[!is.na(NCBI_Build)]
+    if (length(NCBI_Build)==0) NCBI_Build=NA 
 
     if(chatty){
       if(length(NCBI_Build) > 1){


### PR DESCRIPTION
This modif 
is in case of the user maf file contain a NCBI_Build column but with all values missing   This is the case in Center column 

for a reproducible example 

maf=data.frame(Hugo_Symbol=c("TP53","EGFR","ERBB3","TP53"),
           Tumor_Sample_Barcode=c("P01","P01","P02","P02"),
           Chromosome=c(17,7,12,17),
           Variant_Classification=rep("Missense_Mutation",4),
           Variant_Type=rep("SNP",4),
           Start_Position=c(3,5,8 ,9),
           End_Position=c(3,5,8,9),
           Reference_Allele=c("G","G","A","G"),
           Tumor_Seq_Allele2=c("T","T","C","T"),
           NCBI_Build=NA,
           Center=NA
           )
maf_obj=read.maf(maf) # note here a warning is pulled out by the data.table function : Warning: Item 2 has 5 rows but longest item has 6; recycled with remainder. maf_obj@summary  # note here the summary has false Sample number