### PR TITLE
Fix mismatched pathways (#923)

### DIFF
--- a/R/oncomatrix.R
+++ b/R/oncomatrix.R
@@ -729,6 +729,6 @@ get_pw_summary = function(maf, pathways = NULL){
   altered_pws$Mutated_samples = unlist(mut_load)
   nsamps = as.numeric(maf@summary[ID == "Samples", summary])
   altered_pws[,Fraction_mutated_samples := Mutated_samples/nsamps]
-  altered_pws = altered_pws[order(n_affected_genes, fraction_affected, decreasing = FALSE)]
+  #altered_pws = altered_pws[order(n_affected_genes, fraction_affected, decreasing = FALSE)]
   altered_pws
 }

--- a/R/oncomatrix.R
+++ b/R/oncomatrix.R
@@ -721,7 +721,8 @@ get_pw_summary = function(maf, pathways = NULL){
   altered_pws = as.data.frame(t(data.frame(lapply(altered_pws, length))))
   data.table::setDT(x = altered_pws, keep.rownames = TRUE)
   colnames(altered_pws) = c("Pathway", "n_affected_genes")
-  altered_pws$Pathway = gsub(pattern = "\\.", replacement = "-", x = altered_pws$Pathway)
+  #altered_pws$Pathway = gsub(pattern = "\\.", replacement = "-", x = altered_pws$Pathway)
+  altered_pws$Pathway = names(pathdb)
   altered_pws = merge(pathdb_size, altered_pws, all.x = TRUE)
 
   altered_pws[, fraction_affected := n_affected_genes/N]


### PR DESCRIPTION
If pathways in pathdb contain spaces or non-hyphen characters (eg "/"), the merge in lines 724-725 does not work correctly. I have made a quick fix which works on my issue #923 